### PR TITLE
export cert in memory if no file is specified

### DIFF
--- a/lib/keytool.js
+++ b/lib/keytool.js
@@ -335,13 +335,14 @@ var Keytool = function Keytool(keystore, storepass, options) {
     var exportcert = function exportcert(alias, filename, rfcoutput, cb) { 
         cb = arguments[arguments.length-1];
 
-        var callargs = ['-exportcert', '-alias', alias, '-file', filename];
+        var callargs = ['-exportcert', '-alias', alias];
         if (rfcoutput === true) callargs.push('-rfc');
+        if (filename) callargs.push('-file', filename);
 
         callKeytool(callargs, undefined, function(code, stdout, stderr) {
             if (handleResult(code, stdout, stderr, cb)) return;
 
-            cb(null, {alias: alias});
+            cb(null, {alias: alias, cert: stdout});
         });
 
         return this;


### PR DESCRIPTION
for certain situations it is helpful to export the cert in memory for use in further verification steps. 
