### PR TITLE
Require English output when calling keytool (Fixes issue #6)

### DIFF
--- a/lib/keytool.js
+++ b/lib/keytool.js
@@ -36,7 +36,7 @@ var Keytool = function Keytool(keystore, storepass, options) {
         };
         var executable = opts.executable || 'keytool';
 
-        var storeargs = ['-noprompt', '-keystore', keystore, '-storepass', storepass, '-storetype', storetype];
+        var storeargs = ['-J-Duser.language=en', '-noprompt', '-keystore', keystore, '-storepass', storepass, '-storetype', storetype];
         args = args.concat(storeargs);
         if ('extraargs' in opts) {
             args = args.concat(opts.extraargs);


### PR DESCRIPTION
Quick-fix for #6.

Would be great if you publish a version `0.0.4` on [npmjs.com](https://www.npmjs.com/package/node-keytool).
